### PR TITLE
respect ffprove output filesize

### DIFF
--- a/lib/ffmpeg/movie.rb
+++ b/lib/ffmpeg/movie.rb
@@ -49,6 +49,7 @@ module FFMPEG
                          end
 
         @bitrate = metadata[:format][:bit_rate].to_i
+        @size = metadata[:format][:size].to_i
 
         unless video_streams.empty?
           # TODO: Handle multiple video codecs (is that possible?)
@@ -114,7 +115,11 @@ module FFMPEG
     end
 
     def size
-      File.size(@path)
+      if @size
+        @size
+      else
+        File.size(@path)
+      end 
     end
 
     def audio_channel_layout

--- a/spec/ffmpeg/movie_spec.rb
+++ b/spec/ffmpeg/movie_spec.rb
@@ -44,6 +44,11 @@ module FFMPEG
         it "should have nil frame_rate" do
           @movie.frame_rate.should be_nil
         end
+
+        it "should know the file size" do
+          File.should_receive(:size).with(__FILE__).and_return(1)
+          @movie.size.should == 1
+        end
       end
 
       context "given an empty flv file (could not find codec parameters)" do


### PR DESCRIPTION
Because, when allow url as the `@path`, we will not be able to use the `File.size`.