### PR TITLE
Added 'fit' preserve_aspect_ratio option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Aspect ratio is added to encoding options automatically if none is specified.
 options = { resolution: "320x180" } # Will add -aspect 1.77777777777778 to ffmpeg
 ```
 
-Preserve aspect ratio on width or height by using the preserve_aspect_ratio transcoder option.
+Preserve aspect ratio by using the preserve_aspect_ratio transcoder option.
 
 ``` ruby
 widescreen_movie = FFMPEG::Movie.new("path/to/widescreen_movie.mov")
@@ -121,6 +121,10 @@ widescreen_movie.transcode("movie.mp4", options, transcoder_options) # Output re
 
 transcoder_options = { preserve_aspect_ratio: :height }
 widescreen_movie.transcode("movie.mp4", options, transcoder_options) # Output resolution will be 426x240
+
+options = { resolution: "240x320" } # portrait
+transcoder_options = { preserve_aspect_ratio: :fit }
+widescreen_movie.transcode("movie.mp4", options, transcoder_options) # Output resolution will be 240x180
 ```
 
 For constant bitrate encoding use video_min_bitrate and video_max_bitrate with buffer_size.

--- a/spec/ffmpeg/transcoder_spec.rb
+++ b/spec/ffmpeg/transcoder_spec.rb
@@ -129,6 +129,60 @@ module FFMPEG
             encoded = Transcoder.new(@movie, "#{tmp_path}/preserved_aspect.mp4", @options, special_options).run
             encoded.resolution.should == "320x260" # 320 / 1.234 should at first be rounded to 259
           end
+
+          context "fit" do
+            before :each do
+              @special_options = {preserve_aspect_ratio: :fit}
+            end
+
+            it "should preserve width when input is landscape and options resolution is portrait" do
+              movie = Movie.new("#{fixture_path}/movies/awesome_widescreen.mov")
+              options = {resolution: "360x640"}
+
+              encoded = Transcoder.new(movie, "#{tmp_path}/preserved_aspect.mp4", options, @special_options).run
+              encoded.resolution.should == "360x202"
+            end
+
+            it "should preserve height when input is portrait and options resolution is landscape" do
+              movie = Movie.new("#{fixture_path}/movies/sideways movie.mov")
+              options = {resolution: "640x360"}
+
+              encoded = Transcoder.new(movie, "#{tmp_path}/preserved_aspect.mp4", options, @special_options).run
+              encoded.resolution.should == "270x360"
+            end
+
+            it "should preserve height when input is portrait and options resolution is a shorter portrait" do
+              movie = Movie.new("#{fixture_path}/movies/sideways movie.mov")
+              options = {resolution: "480x600"}
+
+              encoded = Transcoder.new(movie, "#{tmp_path}/preserved_aspect.mp4", options, @special_options).run
+              encoded.resolution.should == "450x600"
+            end
+
+            it "should preserve width when input is portrait and options resolution is a taller portrait" do
+              movie = Movie.new("#{fixture_path}/movies/sideways movie.mov")
+              options = {resolution: "360x640"}
+
+              encoded = Transcoder.new(movie, "#{tmp_path}/preserved_aspect.mp4", options, @special_options).run
+              encoded.resolution.should == "360x480"
+            end
+
+            it "should preserve width when input is landscape and options resolution is narrower landscape" do
+              movie = Movie.new("#{fixture_path}/movies/awesome_widescreen.mov")
+              options = {resolution: "640x480"}
+
+              encoded = Transcoder.new(movie, "#{tmp_path}/preserved_aspect.mp4", options, @special_options).run
+              encoded.resolution.should == "640x360"
+            end
+
+            it "should preserve height when input is landscape and options resolution is wider landscape" do
+              movie = Movie.new("#{fixture_path}/movies/awesome_widescreen.mov")
+              options = {resolution: "1280x360"}
+
+              encoded = Transcoder.new(movie, "#{tmp_path}/preserved_aspect.mp4", options, @special_options).run
+              encoded.resolution.should == "640x360"
+            end
+          end
         end
 
         it "should transcode the movie with String options" do


### PR DESCRIPTION
Adds `preserve_aspect_ratio: :fit` to transcoder options. This adjusts either the height or width to be adjusted so that the output always fits within the resolution specified by `:resolution` in the options hash.